### PR TITLE
pull request to address issue #13: "setuptools packaging"

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+*.egg-info/*
+*.egg/*
+*/.idea/*

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,2 @@
+include README LICENSE README
+recursive-include creepy/include/*

--- a/creepy/urlanalyzer.py
+++ b/creepy/urlanalyzer.py
@@ -22,7 +22,7 @@ This file is part of creepy.
 import re
 import urllib, simplejson
 import urllib2
-import pyexiv2
+
 import time
 import os.path
 from datetime import datetime
@@ -30,6 +30,12 @@ from time import  mktime
 from urlparse import urlparse
 from BeautifulSoup import BeautifulSoup as bs
 
+try:
+    import pyexiv2
+except ImportError:
+    PYEXIV_AVAILABLE = False
+else:
+    PYEXIV_AVAILABLE = True
 
 class URLAnalyzer():
     """
@@ -96,6 +102,15 @@ class URLAnalyzer():
 
 
     def exif_extract(self, temp_file, tweet):
+        """
+        Attempt to extract exif information from the provided tweet.
+        If pyexiv2 dependency is not installed, this will not work and will
+        merely return an empty list
+        """
+
+        if not PYEXIV_AVAILABLE:
+            return []
+
         def calc(k): return [(float(n)/float(d)) for n,d in [k.split("/")]][0]
         def degtodec(a): return a[0]+a[1]/60+a[2]/3600
         def format_coordinates(string):

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,101 @@
+import sys
+
+from itertools import chain
+from os.path import join, dirname
+from setuptools import setup, find_packages
+
+__version__ = '0.2.0'
+package_name = 'creepy'
+# used to specify that a feature should depend on the presence
+# of another feature
+intra_dependency = '%s[%%s]==%s' % (package_name, __version__)
+
+def read(name, *args):
+    try:
+        with open(join(dirname(__file__), name)) as read_obj:
+            return read_obj.read(*args)
+    except Exception:
+        return ''
+
+def test_and_add_imports(module, requirement, requirements, feature, link):
+    """
+    used to test for the presence of modules already present in the
+    python path. For example, those installed via yum or apt-get
+    """
+    try:
+        __import__(module)
+    except ImportError:
+        print >> sys.stderr, ('%s not found, try download packages '
+                              'from: %s' % (module, link))
+        requirements[feature].append(requirement)
+
+
+# this supports people installing the specific features of creepy they
+# need, without the need to bring in all the third-party requirements
+extras_require = {
+    'flickr': [
+        'flickrapi==1.4.2',
+        ],
+    'twitter': [
+        'tweepy==1.7.1',
+    ],
+
+    'exif': [],
+    'map': [
+        intra_dependency % 'flickr',
+        intra_dependency % 'twitter',
+    ],
+
+}
+
+# not on pypi:
+test_and_add_imports('pyexiv2', 'pyexiv2==0.3.0', extras_require, 'exif',
+                     'http://tilloy.net/dev/pyexiv2/download.html')
+# not on pypi
+# apt-get install libosmgpsmap-dev python-osmgpsmap
+test_and_add_imports('osmgpsmap', 'osmgpsmap==0.7.2', extras_require, 'map',
+                     'http://nzjrs.github.com/osm-gps-map/')
+# not installable via distutils, available on ubuntu with:
+# apt-get install python-gtk (or python-gtk2)
+test_and_add_imports('gtk.gdk', 'PyGTK==2.12.1', extras_require, 'map',
+                     'http://www.pygtk.org/downloads.html')
+# not installable via distutils, available on ubuntu with:
+# apt-get install python-gobject
+test_and_add_imports('gobject', 'PyGObject==2.10.1', extras_require, 'map',
+                     'http://www.pygtk.org/downloads.html')
+
+all_unique_packages = set(list(chain(*extras_require.values())))
+
+extras_require['all'] = list(all_unique_packages)
+
+# baseline requirements that the core functionality requires
+install_requires = [
+    'configobj==4.7.2',
+    'BeautifulSoup==3.2.0',
+    'simplejson==2.2.1',
+]
+
+# in case additional setup needs to be done on different versions of python
+extra_setup = {}
+
+setup(
+    name=package_name,
+    version=__version__,
+    description='A geolocation information gatherer. Offers geolocation '
+                'information gathering through social networking platforms',
+    long_description=read('README'),
+    # packaging by Rob Dennis <rdennis@gmail.com>
+    author='Yiannis Kakavas',
+    author_email=' jkakavas@gmail.com',
+    url='https://github.com/ilektrojohn/creepy/',
+    install_requires=install_requires,
+    extras_require=extras_require,
+    packages=find_packages(exclude=['ez_setup']),
+    classifiers=[
+    'License :: OSI Approved :: GNU General Public License (GPL)',
+    'Programming Language :: Python',
+    'Programming Language :: Python :: 2',
+    'Topic :: Security',
+    ],
+    **extra_setup
+)


### PR DESCRIPTION
Hello, I'm interested in using a subset of creepy's functionality in a project of mine, and it would be convenient from me to have an explicit dependency of creepy[twitter] (for example). (here's the relevant link to python's handling of 'features': http://packages.python.org/distribute/setuptools.html?highlight=extra#declaring-extras-optional-features-with-their-own-dependencies)

I saw issue #13 and am submitting a pull request where I:
- added setup.py packaging with 4 features (flickr/twitter/exif/map) to support people depending on a subset of creepy functionality
- modified urlanalyzer to not throw import error in the event of the exif feature not being present, as the module is used by this twitter/flickr modules
- bumped version to 0.2.0 as adding packaging with setuptools extra features is at least a minor level change

testing steps I performed:
fresh ubuntu VM
(install items not on pypi or just not installable with distutils)
apt-get install python-pyexiv2 libosmgpsmap-dev python-osmgpsmap python-gtk python-gobject
python (>2.6) setup.py develop # installs all the base requirements
easy_install creepy[all] # installs all the optional dependencies and verifies that the above items (non-pypi modules) are installed

if the apt-get step was skipped and the feature was specified (e.g. creepy[map] or creepy[all]), a warning would be displayed with a link to the projects download page

Thanks, appreciate the work and hopefully this is something that you find useful
